### PR TITLE
Handle kernel queue overflow on windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven'
 
 group = 'com.aerofs'
 archivesBaseName = 'jnotify'
-version = '0.95'
+version = '0.96'
 
 compileJava {
     options.compilerArgs << '-Werror'

--- a/src/main/java/net/contentobjects/jnotify/linux/JNotify_linux.java
+++ b/src/main/java/net/contentobjects/jnotify/linux/JNotify_linux.java
@@ -42,120 +42,111 @@ import static net.contentobjects.jnotify.Util.CHARSET_UTF;
 
 public class JNotify_linux
 {
-	static final boolean DEBUG = false;
-	public static boolean WARN = true;
-	
-	static
-	{
-		int res = nativeInit();
-		if (res != 0)
-		{
-			throw new RuntimeException("Error initializing fshook_inotify library. linux error code #" + res  + ", man errno for more info");
-		}
-		init();
-	}
-	
-	/* the following are legal, implemented events that user-space can watch for */
-	public final static int IN_ACCESS = 0x00000001; /* File was accessed */
-	public final static int IN_MODIFY = 0x00000002; /* File was modified */
-	public final static int IN_ATTRIB = 0x00000004; /* Metadata changed */
-	public final static int IN_CLOSE_WRITE = 0x00000008; /* Writtable file was closed */
-	public final static int IN_CLOSE_NOWRITE = 0x00000010; /* Unwrittable file closed */
-	public final static int IN_OPEN = 0x00000020; /* File was opened */
-	public final static int IN_MOVED_FROM = 0x00000040; /* File was moved from X */
-	public final static int IN_MOVED_TO = 0x00000080; /* File was moved to Y */
-	public final static int IN_CREATE = 0x00000100; /* Subfile was created */
-	public final static int IN_DELETE = 0x00000200; /* Subfile was deleted */
-	public final static int IN_DELETE_SELF = 0x00000400; /* Self was deleted */
-	public final static int IN_MOVE_SELF = 0x00000800; /* Self was moved */
+    static
+    {
+        int res = nativeInit();
+        if (res != 0)
+        {
+            throw new RuntimeException("Error initializing fshook_inotify library. linux error code #" + res  + ", man errno for more info");
+        }
+        init();
+    }
+    
+    /* the following are legal, implemented events that user-space can watch for */
+    public final static int IN_ACCESS = 0x00000001; /* File was accessed */
+    public final static int IN_MODIFY = 0x00000002; /* File was modified */
+    public final static int IN_ATTRIB = 0x00000004; /* Metadata changed */
+    public final static int IN_CLOSE_WRITE = 0x00000008; /* Writtable file was closed */
+    public final static int IN_CLOSE_NOWRITE = 0x00000010; /* Unwrittable file closed */
+    public final static int IN_OPEN = 0x00000020; /* File was opened */
+    public final static int IN_MOVED_FROM = 0x00000040; /* File was moved from X */
+    public final static int IN_MOVED_TO = 0x00000080; /* File was moved to Y */
+    public final static int IN_CREATE = 0x00000100; /* Subfile was created */
+    public final static int IN_DELETE = 0x00000200; /* Subfile was deleted */
+    public final static int IN_DELETE_SELF = 0x00000400; /* Self was deleted */
+    public final static int IN_MOVE_SELF = 0x00000800; /* Self was moved */
 
-	/* the following are legal events. they are sent as needed to any watch */
-	public final static int IN_UNMOUNT = 0x00002000; /* Backing fs was unmounted */
-	public final static int IN_Q_OVERFLOW = 0x00004000; /* Event queued overflowed */
-	public final static int IN_IGNORED = 0x00008000; /* File was ignored */
+    /* the following are legal events. they are sent as needed to any watch */
+    public final static int IN_UNMOUNT = 0x00002000; /* Backing fs was unmounted */
+    public final static int IN_Q_OVERFLOW = 0x00004000; /* Event queued overflowed */
+    public final static int IN_IGNORED = 0x00008000; /* File was ignored */
 
-	/* helper events */
-	public final static int IN_CLOSE = (IN_CLOSE_WRITE | IN_CLOSE_NOWRITE); /* close */
-	public final static int IN_MOVE = (IN_MOVED_FROM | IN_MOVED_TO); /* moves */
+    /* helper events */
+    public final static int IN_CLOSE = (IN_CLOSE_WRITE | IN_CLOSE_NOWRITE); /* close */
+    public final static int IN_MOVE = (IN_MOVED_FROM | IN_MOVED_TO); /* moves */
 
-	/* special flags */
-	public final static int IN_ISDIR = 0x40000000; /*
-													 * event occurred against
-													 * dir
-													 */
-	public final static int IN_ONESHOT = 0x80000000; /* only send event once */
+    /* special flags */
+    public final static int IN_ISDIR = 0x40000000; /*
+                                                     * event occurred against
+                                                     * dir
+                                                     */
+    public final static int IN_ONESHOT = 0x80000000; /* only send event once */
 
-	/*
-	 * All of the events - we build the list by hand so that we can add flags in
-	 * the future and not break backward compatibility. Apps will get only the
-	 * events that they originally wanted. Be sure to add new events here!
-	 */
-	public final static int IN_ALL_EVENT = (IN_ACCESS | IN_MODIFY | IN_ATTRIB | IN_CLOSE_WRITE
-			| IN_CLOSE_NOWRITE | IN_OPEN | IN_MOVED_FROM | IN_MOVED_TO | IN_DELETE | IN_CREATE | IN_DELETE_SELF);
-	
-	
-	private static INotifyListener _notifyListener;
+    /*
+     * All of the events - we build the list by hand so that we can add flags in
+     * the future and not break backward compatibility. Apps will get only the
+     * events that they originally wanted. Be sure to add new events here!
+     */
+    public final static int IN_ALL_EVENT = (IN_ACCESS | IN_MODIFY | IN_ATTRIB | IN_CLOSE_WRITE
+            | IN_CLOSE_NOWRITE | IN_OPEN | IN_MOVED_FROM | IN_MOVED_TO | IN_DELETE | IN_CREATE | IN_DELETE_SELF);
+    
+    
+    private static INotifyListener _notifyListener;
 
-	private static native int nativeInit();
-	
-	private static native int nativeAddWatch(byte[] path, int mask);
+    private static native int nativeInit();
+    
+    private static native int nativeAddWatch(byte[] path, int mask);
 
-	private static native int nativeRemoveWatch(int wd);
-	
-	private native static int nativeNotifyLoop();
-	
-	private static native String getErrorDesc(long errorCode);
-	
-	
-	public static int addWatch(String path, int mask) throws JNotifyException
-	{
-		int wd = nativeAddWatch(path.getBytes(CHARSET_UTF), mask);
-		if (wd < 0)
-		{
-			throw new JNotifyException_linux("Error watching " + path + " : " + getErrorDesc(-wd), -wd);
-		}
-		return wd;
-	}
+    private static native int nativeRemoveWatch(int wd);
+    
+    private native static int nativeNotifyLoop();
+    
+    private static native String getErrorDesc(long errorCode);
+    
+    
+    public static int addWatch(String path, int mask) throws JNotifyException
+    {
+        int wd = nativeAddWatch(path.getBytes(CHARSET_UTF), mask);
+        if (wd < 0) {
+            throw new JNotifyException_linux("Error watching " + path + " : " + getErrorDesc(-wd), -wd);
+        }
+        return wd;
+    }
 
-	public static void removeWatch(int wd) throws JNotifyException
-	{
-		int ret = nativeRemoveWatch(wd);
-		if (ret != 0)
-		{
-			throw new JNotifyException_linux("Error removing watch " + wd, ret);
-		}
-	}
-	
-	private static void init()
-	{
-		Thread thread = new Thread("fs")
-		{
-			public void run()
-			{
-				nativeNotifyLoop();
-			}
-		};
-		thread.setDaemon(true);
-		thread.start();
-	}
-	
-	static void callbackProcessEvent(byte[] name, int wd, int mask, int cookie)
-	{
-		if (_notifyListener != null)
-		{
-			_notifyListener.notify(new String(name, CHARSET_UTF), wd, mask, cookie);
-		}
-	}
+    public static void removeWatch(int wd) throws JNotifyException
+    {
+        int ret = nativeRemoveWatch(wd);
+        if (ret != 0) {
+            throw new JNotifyException_linux("Error removing watch " + wd, ret);
+        }
+    }
+    
+    private static void init()
+    {
+        Thread thread = new Thread("fs") {
+            public void run()
+            {
+                nativeNotifyLoop();
+            }
+        };
+        thread.setDaemon(true);
+        thread.start();
+    }
+    
+    static void callbackProcessEvent(byte[] name, int wd, int mask, int cookie)
+    {
+        if (_notifyListener != null) {
+            _notifyListener.notify(new String(name, CHARSET_UTF), wd, mask, cookie);
+        }
+    }
 
-	public static void setNotifyListener(INotifyListener notifyListener)
-	{
-		if (_notifyListener == null)
-		{
-			_notifyListener = notifyListener;
-		}
-		else
-		{
-			throw new RuntimeException("Notify listener is already set. multiple notify listeners are not supported.");
-		}
-	}
+    public static void setNotifyListener(INotifyListener notifyListener)
+    {
+        if (_notifyListener == null)
+        {
+            _notifyListener = notifyListener;
+        } else {
+            throw new RuntimeException("Notify listener is already set. multiple notify listeners are not supported.");
+        }
+    }
 }

--- a/src/main/java/net/contentobjects/jnotify/win32/IWin32NotifyListener.java
+++ b/src/main/java/net/contentobjects/jnotify/win32/IWin32NotifyListener.java
@@ -38,5 +38,5 @@ package net.contentobjects.jnotify.win32;
 
 public interface IWin32NotifyListener
 {
-	public void notifyChange(int wd, int action, String rootPath, String filePath);
+    void notifyChange(int wd, int action, String filePath);
 }

--- a/src/main/java/net/contentobjects/jnotify/win32/JNotify_win32.java
+++ b/src/main/java/net/contentobjects/jnotify/win32/JNotify_win32.java
@@ -69,22 +69,23 @@ public class JNotify_win32
     public static final int FILE_ACTION_MODIFIED = 0x00000003;
     public static final int FILE_ACTION_RENAMED_OLD_NAME = 0x00000004;
     public static final int FILE_ACTION_RENAMED_NEW_NAME = 0x00000005;
+    public static final int FILE_ACTION_QUEUE_OVERFLOW   = -1;
 
-    private static native void nativeInitLogger(byte[] path);
+    private static native void nativeInitLogger(byte[] path, boolean debug);
     private static native int nativeInit();
-    private static native int nativeAddWatch(String path, long mask, boolean watchSubtree);
-    private static native String getErrorDesc(long errorCode);
+    private static native int nativeAddWatch(String path, int mask, boolean watchSubtree);
+    private static native String getErrorDesc(int errorCode);
     private static native void nativeRemoveWatch(int wd);
 
     private static boolean _eventThreadRenamed = false;
     private static IWin32NotifyListener _notifyListener;
 
-    public static void initLogger(String path)
+    public static void initLogger(String path, boolean debug)
     {
-        nativeInitLogger(path.getBytes(CHARSET_UTF));
+        nativeInitLogger(path.getBytes(CHARSET_UTF), debug);
     }
 
-    public static int addWatch(String path, long mask, boolean watchSubtree) throws JNotifyException
+    public static int addWatch(String path, int mask, boolean watchSubtree) throws JNotifyException
     {
         int wd = nativeAddWatch(path, mask, watchSubtree);
         if (wd < 0) {
@@ -98,7 +99,7 @@ public class JNotify_win32
         nativeRemoveWatch(wd);
     }
 
-    public static void callbackProcessEvent(int wd, int action, String rootPath, String filePath)
+    public static void callbackProcessEvent(int wd, int action, String filePath)
     {
         // the event thread is created in the native code using Win32 API directly
         // so the simplest way to change its name on the Java side (for logging
@@ -108,7 +109,7 @@ public class JNotify_win32
         }
 
         if (_notifyListener != null) {
-            _notifyListener.notifyChange(wd, action, rootPath, filePath);
+            _notifyListener.notifyChange(wd, action, filePath);
         }
     }
 

--- a/win32/Logger.cpp
+++ b/win32/Logger.cpp
@@ -32,6 +32,7 @@
 
 #include "Logger.h"
 
+#include <ctime>
 #include <stdio.h>
 #include <windows.h>
 #include "Lock.h"
@@ -41,14 +42,17 @@ namespace {
 Lock _logLoc;
 FILE *logFile = 0;
 
-const bool DEBUG = false;
-const bool LOG = true;
+bool LOG = false;
+bool DEBUG = false;
 
 char sbuf[1024];
 
 void _log()
 {
-    if (logFile == 0) return;
+    SYSTEMTIME t;
+    GetSystemTime(&t);
+    fprintf(logFile, "[%04d-%02d-%02d %02d:%02d:%02d,%03d] ",
+            t.wYear, t.wMonth, t.wDay, t.wHour, t.wMinute, t.wSecond, t.wMilliseconds);
     fputs(sbuf, logFile);
     fputc('\n', logFile);
     fflush(logFile);
@@ -57,12 +61,14 @@ void _log()
 }
 
 // TODO: rotate log file
-void initLog(const char *path)
+void initLog(const char *path, bool debug)
 {
     if (logFile != 0) {
         fclose(logFile);
     }
     logFile = fopen(path, "a");
+    LOG = logFile != 0;
+    DEBUG = debug && LOG;
 }
 
 void debug(const char *format, ...)

--- a/win32/Logger.h
+++ b/win32/Logger.h
@@ -35,7 +35,7 @@
 
 #include <stdio.h>
 
-void initLog(const char *logFile);
+void initLog(const char *logFile, bool debug);
 
 void log(const char *format, ...);
 void debug(const char *format, ...);

--- a/win32/WatchData.cpp
+++ b/win32/WatchData.cpp
@@ -29,8 +29,6 @@
  * Author : Omry Yadan
  ******************************************************************************/
 
- 
-
 #include "WatchData.h"
 #include "Logger.h"
 
@@ -42,70 +40,59 @@ WatchData::WatchData()
 
 WatchData::~WatchData()
 {
-	if (_path != NULL) free(_path);
-	_hDir = 0;
+    if (_path != NULL) free(_path);
+    _hDir = 0;
 }
 
 WatchData::WatchData(const WCHAR* path, int mask, bool watchSubtree, HANDLE completionPort)
-	:
-	_watchId(++_counter), 
-	_mask(mask), 
-	_watchSubtree(watchSubtree),
-	_byteReturned(0),
-	_completionPort(completionPort)
+    :
+    _watchId(++_counter), 
+    _mask(mask), 
+    _watchSubtree(watchSubtree),
+    _byteReturned(0),
+    _completionPort(completionPort)
 {
-	_path = _wcsdup(path); 
-	_hDir = CreateFileW(_path,
-						 FILE_LIST_DIRECTORY | GENERIC_READ,
-						 FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-						 NULL, //security attributes
-						 OPEN_EXISTING,
-						 FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED, NULL);
-	if(_hDir == INVALID_HANDLE_VALUE )	
-	{
-		throw GetLastError();
-	}
-	
-	if (NULL == CreateIoCompletionPort(_hDir, _completionPort, (ULONG_PTR)_watchId, 0))
-	{
-		throw GetLastError();
-	}
+    _path = _wcsdup(path); 
+    _hDir = CreateFileW(_path,
+                        FILE_LIST_DIRECTORY | GENERIC_READ,
+                        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                        NULL, //security attributes
+                        OPEN_EXISTING,
+                        FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED, NULL);
+    if (_hDir == INVALID_HANDLE_VALUE) {
+        throw GetLastError();
+    }
+    
+    if (NULL == CreateIoCompletionPort(_hDir, _completionPort, (ULONG_PTR)_watchId, 0)) {
+        throw GetLastError();
+    }
 }
 
 int WatchData::unwatchDirectory()
 {
-	int c = CancelIo(_hDir);
-	if (_hDir != INVALID_HANDLE_VALUE) CloseHandle(_hDir);
-	if (c == 0)
-	{
-		return GetLastError();
-	}
-	else
-	{
-		return 0;
-	}
+    int c = CancelIo(_hDir);
+    if (_hDir != INVALID_HANDLE_VALUE) CloseHandle(_hDir);
+    if (c == 0) {
+        return GetLastError();
+    } else {
+        return 0;
+    }
 }
 
 int WatchData::watchDirectory()
 {
-	memset(_buffer, 0, sizeof(_buffer));
-	memset(&_overLapped, 0, sizeof(_overLapped));
-	if( !ReadDirectoryChangesW( _hDir,
-		 					    _buffer,//<--FILE_NOTIFY_INFORMATION records are put into this buffer
-								sizeof(_buffer),
-								_watchSubtree,
-								_mask,
-								&_byteReturned,
-								&_overLapped,
-								NULL))
-
-
-
-	{
-		return GetLastError();
-	}
-	else
-	{
-		return 0;
-	}
+    memset(_buffer, 0, sizeof(_buffer));
+    memset(&_overLapped, 0, sizeof(_overLapped));
+    if (!ReadDirectoryChangesW(_hDir,
+                               _buffer,//<--FILE_NOTIFY_INFORMATION records are put into this buffer
+                               sizeof(_buffer),
+                               _watchSubtree,
+                               _mask,
+                               &_byteReturned,
+                               &_overLapped,
+                               NULL)) {
+        return GetLastError();
+    } else {
+        return 0;
+    }
 }

--- a/win32/WatchData.h
+++ b/win32/WatchData.h
@@ -29,8 +29,6 @@
  * Author : Omry Yadan
  ******************************************************************************/
 
-
-
 #ifndef WATCHDATA_H_
 #define WATCHDATA_H_
 
@@ -41,38 +39,35 @@
 
 using namespace std;
 
-typedef void(*ChangeCallback)(int watchID, int action, const WCHAR* rootPath, const WCHAR* filePath);
+typedef void(*ChangeCallback)(int watchID, int action, const WCHAR* filePath, int len);
 
 class WatchData
 {
-private:	
-	static int _counter;
-	WCHAR* _path;
-	int _watchId;
-	HANDLE _hDir;
-	int _mask;
-	bool _watchSubtree;
-	DWORD _byteReturned;
-	OVERLAPPED _overLapped;
-	char _buffer[8196];
-	HANDLE _completionPort;
+private:
+    static int _counter;
+
+    bool _watchSubtree;
+    int _watchId;
+    int _mask;
+    DWORD _byteReturned;
+    WCHAR* _path;
+    HANDLE _hDir;
+    HANDLE _completionPort;
+    OVERLAPPED _overLapped;
+    char _buffer[8196];
 public:
-	WatchData();
-	WatchData(const WCHAR* path, int mask, bool watchSubtree, HANDLE completionPort);
-	virtual ~WatchData();
-	
-	const char* getBuffer(){ return _buffer;}
-//	FILE_NOTIFY_INFORMATION* getNotifyInfo(){return _notifyInfo;}
-	const int getBufferSize() {return sizeof(_buffer);}
-//	const DWORD getBytesReturned() {return _byteReturned;}
-	const WCHAR* getPath() {return _path;}
-	const int getId() {return _watchId;}
-//	const HANDLE getDirHandle() {return _hDir;}
-//	const int getMask() {return _mask;}
-	int watchDirectory();
-	
-	// cancel pending watch on the hDir, returns 0 if okay or errorCode otherwise.
-	int unwatchDirectory();
+    WatchData();
+    WatchData(const WCHAR* path, int mask, bool watchSubtree, HANDLE completionPort);
+    virtual ~WatchData();
+    
+    const char* getBuffer(){ return _buffer;}
+    const int getBufferSize() {return sizeof(_buffer);}
+    const WCHAR* getPath() {return _path;}
+    const int getId() {return _watchId;}
+    int watchDirectory();
+    
+    // cancel pending watch on the hDir, returns 0 if okay or errorCode otherwise.
+    int unwatchDirectory();
 };
 
 #endif /*WATCHDATA_H_*/

--- a/win32/Win32FSHook.cpp
+++ b/win32/Win32FSHook.cpp
@@ -29,7 +29,6 @@
  * Author : Omry Yadan
  ******************************************************************************/
 
-
 #include "Win32FSHook.h"
 #include <stdio.h>
 #include <windows.h>
@@ -45,269 +44,253 @@ Win32FSHook *Win32FSHook::instance = 0;
 
 Win32FSHook::Win32FSHook() 
 {
-	_callback = 0;
-	_mainLoopThreadHandle = INVALID_HANDLE_VALUE;
-	_eventsThread = INVALID_HANDLE_VALUE;
-	_isRunning = false;
-	InitializeCriticalSection(&_cSection);
-	InitializeCriticalSection(&_eventQueueLock);
-	_eventQueueEvent = CreateEvent(NULL, FALSE,FALSE, NULL);
+    _callback = 0;
+    _mainLoopThreadHandle = INVALID_HANDLE_VALUE;
+    _eventsThread = INVALID_HANDLE_VALUE;
+    _isRunning = false;
+    InitializeCriticalSection(&_cSection);
+    InitializeCriticalSection(&_eventQueueLock);
+    _eventQueueEvent = CreateEvent(NULL, FALSE,FALSE, NULL);
 }
 
 void Win32FSHook::init(ChangeCallback callback)
 {
-	instance = this;
-	_callback = callback;
-	if (!_isRunning)
-	{
-		_completionPort = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, 1);
-		if (_completionPort == NULL)
-		{
-			throw GetLastError();
-		}
-		_isRunning = true;
-		
-	    DWORD dwThreadId;
-	    LPVOID dwThrdParam = (LPVOID)this; 
-	    _mainLoopThreadHandle = CreateThread( 
-	        NULL,                        // default security attributes 
-	        0,                           // use default stack size  
-	        Win32FSHook::mainLoop,       // thread function 
-	        dwThrdParam,                // argument to thread function 
-	        0,                           // use default creation flags 
-	        &dwThreadId);                // returns the thread identifier 
-	 
-		if (_mainLoopThreadHandle == NULL) 
-		{
-			throw ERR_INIT_THREAD;
-		}
+    instance = this;
+    _callback = callback;
+    if (!_isRunning) {
+        _completionPort = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, 1);
+        if (_completionPort == NULL) {
+            throw GetLastError();
+        }
+        _isRunning = true;
+        
+        DWORD dwThreadId;
+        LPVOID dwThrdParam = (LPVOID)this; 
+        _mainLoopThreadHandle = CreateThread( 
+            NULL,                        // default security attributes 
+            0,                           // use default stack size  
+            Win32FSHook::mainLoop,       // thread function 
+            dwThrdParam,                // argument to thread function 
+            0,                           // use default creation flags 
+            &dwThreadId);                // returns the thread identifier 
+     
+        if (_mainLoopThreadHandle == NULL) {
+            throw ERR_INIT_THREAD;
+        }
 
-		SetThreadPriority(_mainLoopThreadHandle, THREAD_PRIORITY_TIME_CRITICAL);
-		_eventsThread = CreateThread(
-	        NULL,                        // default security attributes
-	        0,                           // use default stack size
-	        Win32FSHook::eventLoop,       // thread function
-	        dwThrdParam,                // argument to thread function
-	        0,                           // use default creation flags
-	        &dwThreadId);                // returns the thread identifier
+        SetThreadPriority(_mainLoopThreadHandle, THREAD_PRIORITY_TIME_CRITICAL);
+        _eventsThread = CreateThread(
+            NULL,                        // default security attributes
+            0,                           // use default stack size
+            Win32FSHook::eventLoop,       // thread function
+            dwThrdParam,                // argument to thread function
+            0,                           // use default creation flags
+            &dwThreadId);                // returns the thread identifier
 
-		if (_eventsThread == NULL)
-		{
-			CloseHandle(_mainLoopThreadHandle);
-			throw ERR_INIT_THREAD;
-		}
-	}
+        if (_eventsThread == NULL) {
+            CloseHandle(_mainLoopThreadHandle);
+            throw ERR_INIT_THREAD;
+        }
+    }
 }
 
 Win32FSHook::~Win32FSHook()
 {
-	debug("+Win32FSHook destructor");
-	// terminate thread.
-	_isRunning = false;
-	SetEvent(_eventQueueEvent);
-	PostQueuedCompletionStatus(_completionPort, EXIT_SIGNAL, (ULONG_PTR)NULL, NULL);
+    debug("+Win32FSHook destructor");
+    // terminate thread.
+    _isRunning = false;
+    SetEvent(_eventQueueEvent);
+    PostQueuedCompletionStatus(_completionPort, EXIT_SIGNAL, (ULONG_PTR)NULL, NULL);
 
-	// cleanup
-	if (INVALID_HANDLE_VALUE != _mainLoopThreadHandle) CloseHandle(_mainLoopThreadHandle);
-	if (INVALID_HANDLE_VALUE != _eventsThread) CloseHandle(_eventsThread);
-	CloseHandle(_completionPort);
-	DeleteCriticalSection(&_cSection);
-	debug("-Win32FSHook destructor");
+    // cleanup
+    if (INVALID_HANDLE_VALUE != _mainLoopThreadHandle) CloseHandle(_mainLoopThreadHandle);
+    if (INVALID_HANDLE_VALUE != _eventsThread) CloseHandle(_eventsThread);
+    CloseHandle(_completionPort);
+    DeleteCriticalSection(&_eventQueueLock);
+    DeleteCriticalSection(&_cSection);
+    debug("-Win32FSHook destructor");
 }
 
 void Win32FSHook::remove_watch(int wd)
 {
-	debug("+remove_watch(%d)", wd);
-	EnterCriticalSection(&_cSection);
-	map <int, WatchData*>::const_iterator i = _wid2WatchData.find(wd);
-	if (i == _wid2WatchData.end())
-	{
-		debug("remove_watch: watch id %d not found", wd);
-	}
-	else
-	{
-		WatchData *wd = i->second;
-		int res = wd->unwatchDirectory();
-		if (res != 0)
-			log("Error canceling watch on dir %ls : %d",wd->getPath(), res);
-		int res2 = _wid2WatchData.erase(wd->getId());
-		if (res2 != 1)
-			log("Error deleting watch %d from map, res=%d",wd->getId(), res2);
-		PostQueuedCompletionStatus(_completionPort, DELETE_WD_SIGNAL, (ULONG_PTR)wd, NULL);
-	}
-	LeaveCriticalSection(&_cSection);
-	debug("-remove_watch(%d)", wd);
+    debug("+remove_watch(%d)", wd);
+    EnterCriticalSection(&_cSection);
+    map <int, WatchData*>::iterator i = _wid2WatchData.find(wd);
+    if (i == _wid2WatchData.end()) {
+        debug("remove_watch: watch id %d not found", wd);
+    } else {
+        WatchData *wd = i->second;
+        _wid2WatchData.erase(i);
+        int res = wd->unwatchDirectory();
+        if (res != 0) log("Error canceling watch on dir %ls : %d",wd->getPath(), res);
+        PostQueuedCompletionStatus(_completionPort, DELETE_WD_SIGNAL, (ULONG_PTR)wd, NULL);
+    }
+    LeaveCriticalSection(&_cSection);
+    debug("-remove_watch(%d)", wd);
 }
 
-int Win32FSHook::add_watch(const WCHAR* path, long notifyFilter, bool watchSubdirs, DWORD &error)
+int Win32FSHook::add_watch(const WCHAR* path, int notifyFilter, bool watchSubdirs, DWORD &error)
 {
-	debug("+add_watch(%ls)", path);
-	// synchronize access by multiple threads
-	EnterCriticalSection(&_cSection);
-	try
-	{
-		WatchData *watchData = new WatchData(path, notifyFilter, watchSubdirs, _completionPort);
-		if (watchData == 0) throw (DWORD)8; //ERROR_NOT_ENOUGH_MEMORY
-		int watchId = watchData->getId();
-		_wid2WatchData[watchId] = watchData;
-		watchDirectory(watchData);
-		LeaveCriticalSection(&_cSection);
-		return watchId;
-	}
-	catch (DWORD err)
-	{
-		error = err;
-		LeaveCriticalSection(&_cSection);
-		return 0;	
-	}
+    debug("+add_watch(%ls)", path);
+    // synchronize access by multiple threads
+    EnterCriticalSection(&_cSection);
+    try {
+        WatchData *watchData = new WatchData(path, notifyFilter, watchSubdirs, _completionPort);
+        if (watchData == 0) throw (DWORD)8; //ERROR_NOT_ENOUGH_MEMORY
+        int watchId = watchData->getId();
+        _wid2WatchData[watchId] = watchData;
+        watchDirectory(watchData);
+        LeaveCriticalSection(&_cSection);
+        return watchId;
+    } catch (DWORD err) {
+        error = err;
+        LeaveCriticalSection(&_cSection);
+        return 0;    
+    }
 }
 
 WatchData* Win32FSHook::find(int wd)
 {
-	WatchData *watchData = 0;
-	EnterCriticalSection(&_cSection);
-	map <int, WatchData*>::const_iterator it = _wid2WatchData.find(wd);
-	if (it != _wid2WatchData.end())
-	{
-		watchData = it->second;
-	}
-	LeaveCriticalSection(&_cSection);
-	return watchData;
+    WatchData *watchData = 0;
+    EnterCriticalSection(&_cSection);
+    map <int, WatchData*>::const_iterator it = _wid2WatchData.find(wd);
+    if (it != _wid2WatchData.end()) {
+        watchData = it->second;
+    }
+    LeaveCriticalSection(&_cSection);
+    return watchData;
 }
+
+enum {
+    MAX_NAME_LEN = 4096
+};
 
 DWORD WINAPI Win32FSHook::mainLoop( LPVOID lpParam )
 {
-	debug("mainLoop starts");
-	Win32FSHook* _this = (Win32FSHook*)lpParam;
+    debug("main: start");
+    Win32FSHook* _this = (Win32FSHook*)lpParam;
 
-	HANDLE hPort = _this->_completionPort;
-	DWORD dwNoOfBytes = 0;
-	ULONG_PTR ulKey = 0;
-	OVERLAPPED* pov = NULL;
-	WCHAR name[4096];
+    HANDLE hPort = _this->_completionPort;
+    DWORD dwNoOfBytes = 0;
+    ULONG_PTR ulKey = 0;
+    OVERLAPPED* pov = NULL;
 
-	while (_this->_isRunning)
-	{
-	    pov = NULL;
-	    BOOL fSuccess = GetQueuedCompletionStatus(
-	                    hPort,         // Completion port handle
-	                    &dwNoOfBytes,  // Bytes transferred
-	                    &ulKey,
-	                    &pov,          // OVERLAPPED structure
-	                    INFINITE       // Notification time-out interval
-	                    );
-	    if (fSuccess)
-	    {
-	    	if (dwNoOfBytes == 0) continue; // happens when removing a watch some times.
-	    	if (dwNoOfBytes == EXIT_SIGNAL)
-	    		continue;
-	    	if (dwNoOfBytes == DELETE_WD_SIGNAL)
-	    	{
-	    		WatchData *wd = (WatchData*)ulKey;
-	    		delete wd;
-	    		continue;
-	    	}
+    while (_this->_isRunning) {
+        pov = NULL;
+        BOOL fSuccess = GetQueuedCompletionStatus(
+                        hPort,         // Completion port handle
+                        &dwNoOfBytes,  // Bytes transferred
+                        &ulKey,
+                        &pov,          // OVERLAPPED structure
+                        INFINITE       // Notification time-out interval
+                        );
+        if (fSuccess) {
+            if (dwNoOfBytes == EXIT_SIGNAL) {
+                log("main: exit");
+                continue;
+            }
+            if (dwNoOfBytes == DELETE_WD_SIGNAL) {
+                WatchData *wd = (WatchData*)ulKey;
+                log("main: delete %d", wd->getId());
+                delete wd;
+                continue;
+            }
 
-	    	int wd = (int)ulKey;
-//	    	EnterCriticalSection(&_this->_cSection);
-	    	WatchData *watchData = _this->find(wd);
-	    	if (!watchData)
-	    	{
-	    		log("mainLoop : ignoring event for watch id %d, no longer in wid2WatchData map", wd);
-	    		continue;
-	    	}
+            int wd = (int)ulKey;
+            WatchData *watchData = _this->find(wd);
+            if (!watchData) {
+                log("main: ignoring event for removed watch %d", wd);
+                continue;
+            }
 
-	    	const char* buffer = watchData->getBuffer();
-//	    	char buffer[watchData->getBufferSize()];
-//	    	memcpy(buffer, watchData->getBuffer(), dwNoOfBytes);
-//			LeaveCriticalSection(&_this->_cSection);
-	    	FILE_NOTIFY_INFORMATION *event;
-	    	DWORD offset = 0;
-	    	do
-	    	{
-	    		event = (FILE_NOTIFY_INFORMATION*)(buffer+offset);
-	    		int action = event->Action;
-	    		DWORD len = event->FileNameLength / sizeof(WCHAR);
-	    		for (DWORD k=0;k<len && k < (sizeof(name)-sizeof(WCHAR))/sizeof(WCHAR);k++)
-	    		{
-	    			name[k] = event->FileName[k];
-	    		}
-	    		name[len] = 0;
+            if (dwNoOfBytes == 0) {
+                log("main: overflow %d", wd);
+                _this->postEvent(new Event(watchData->getId(), -1, L"", 0));
+            } else {
+                debug("main: recv %d bytes", dwNoOfBytes);
 
-				_this->postEvent(new Event(watchData->getId(), action, watchData->getPath(), name));
-	    		offset += event->NextEntryOffset;
-	    	}
-	    	while (event->NextEntryOffset != 0);
+                const char* buffer = watchData->getBuffer();
+                FILE_NOTIFY_INFORMATION *event;
+                DWORD offset = 0;
+                do {
+                    event = (FILE_NOTIFY_INFORMATION*)(buffer+offset);
+                    int action = event->Action;
+                    DWORD len = event->FileNameLength / sizeof(WCHAR);
+                    if (len > MAX_NAME_LEN) len = MAX_NAME_LEN;
+                    _this->postEvent(new Event(watchData->getId(), action, &event->FileName[0], len));
+                    offset += event->NextEntryOffset;
+                } while (event->NextEntryOffset != 0);
 
-	    	int res = watchData->watchDirectory();
-	    	if (res != 0)
-	    	{
-	    		log("Error watching dir %s : %d",watchData->getPath(), res);
-	    	}
-	    }
-	    else
-	    {
-	    	log("GetQueuedCompletionStatus %d", GetLastError());
-	    }
-	}
-	debug("mainLoop exits");
-	return 0;
+                debug("main: posted");
+            }
+
+            int res = watchData->watchDirectory();
+            if (res != 0) {
+                log("Error watching dir %s : %d",watchData->getPath(), res);
+            }
+        } else {
+            log("GetQueuedCompletionStatus %d", GetLastError());
+        }
+    }
+    debug("main: exit");
+    return 0;
 }
 
 
 void Win32FSHook::watchDirectory(WatchData* wd)
 {
-	debug("Watching %ls", wd->getPath());
-	int res = wd->watchDirectory();
-	if (res != 0)
-	{
-		log("Error watching dir %ls : %d",wd->getPath(), res);
-	}
+    debug("Watching %ls", wd->getPath());
+    int res = wd->watchDirectory();
+    if (res != 0) {
+        log("Error watching dir %ls : %d",wd->getPath(), res);
+    }
 }
 
+// FIXME: the inter-thread communication is gross
+// TODO: use lock-free queue and reduce the number of SetEvent calls
+// TODO: watch queue size
 void Win32FSHook::postEvent(Event *event)
 {
-	EnterCriticalSection(&_eventQueueLock);
-	_eventQueue.push(event);
-	LeaveCriticalSection(&_eventQueueLock);
-	SetEvent(_eventQueueEvent);
+    EnterCriticalSection(&_eventQueueLock);
+    _eventQueue.push(event);
+    LeaveCriticalSection(&_eventQueueLock);
+    SetEvent(_eventQueueEvent);
 }
 
 DWORD WINAPI Win32FSHook::eventLoop( LPVOID lpParam )
 {
-	debug("eventLoop starts");
-	Win32FSHook* _this = (Win32FSHook*)lpParam;
-	queue<Event*> local;
-	while (1)
-	{
-		// quickly copy to local queue, minimizing the time holding the lock
-		EnterCriticalSection(&_this->_eventQueueLock);
-		while(_this->_eventQueue.size() > 0)
-		{
-			Event *e = _this->_eventQueue.front();
-			local.push(e);
-			_this->_eventQueue.pop();
-		}
-		LeaveCriticalSection(&_this->_eventQueueLock);
+    debug("event: start");
+    Win32FSHook* _this = (Win32FSHook*)lpParam;
+    queue<Event*> local;
+    while (1) {
+        debug("event: copy");
+        // quickly copy to local queue, minimizing the time holding the lock
+        EnterCriticalSection(&_this->_eventQueueLock);
+        while (_this->_eventQueue.size() > 0) {
+            Event *e = _this->_eventQueue.front();
+            local.push(e);
+            _this->_eventQueue.pop();
+        }
+        LeaveCriticalSection(&_this->_eventQueueLock);
 
-		while(local.size() > 0)
-		{
-			Event *e = local.front();
-			local.pop();
-			if (_this->_isRunning)
-			{
-				_this->_callback(e->_watchID, e->_action, e->_rootPath, e->_filePath);
-			}
-			delete e;
-		}
+        debug("event: post %d", local.size());
 
-		if (_this->_isRunning)
-		{
-			WaitForSingleObjectEx(_this->_eventQueueEvent, INFINITE, TRUE);
-		}
-		else
-			break;
-	}
-	debug("eventLoop exits");
-	return 0;
+        while (local.size() > 0) {
+            Event *e = local.front();
+            local.pop();
+            if (_this->_isRunning) {
+                _this->_callback(e->_watchID, e->_action, e->_filePath, e->_len);
+            }
+            delete e;
+        }
+        debug("event: posted");
+
+        if (_this->_isRunning) {
+            WaitForSingleObjectEx(_this->_eventQueueEvent, INFINITE, TRUE);
+        } else {
+            break;
+        }
+    }
+    debug("event: exit");
+    return 0;
 }

--- a/win32/Win32FSHook.h
+++ b/win32/Win32FSHook.h
@@ -29,9 +29,6 @@
  * Author : Omry Yadan
  ******************************************************************************/
 
-
- 
-
 #ifndef WIN32FSHOOK_H_
 #define WIN32FSHOOK_H_
 
@@ -41,7 +38,6 @@
 #include <queue>
 #include <utility>
 
-
 #include "WatchData.h"
 
 using namespace std;
@@ -49,75 +45,69 @@ using namespace std;
 class Event
 {
 public:
-	int _watchID;
-	int _action;
-	WCHAR* _rootPath;
-	WCHAR* _filePath;
-	Event(int wd, int action, const WCHAR* rootPath, const WCHAR* filePath)
-	{
-		_watchID = wd;
-		_action = action;
-		size_t len1 = wcslen(rootPath);
-		size_t len2 = wcslen(filePath);
-		_rootPath = new WCHAR[len1 + 1];
-		_filePath = new WCHAR[len2 + 1];
-		wcsncpy(_rootPath, rootPath, len1);
-		_rootPath[len1] = 0;
-		wcsncpy(_filePath, filePath, len2);
-		_filePath[len2] = 0;
-	}
+    int _watchID;
+    int _action;
+    int _len;
+    WCHAR* _filePath;
+    Event(int wd, int action, const WCHAR* filePath, int len)
+    {
+        _watchID = wd;
+        _action = action;
+        _len = len;
+        _filePath = new WCHAR[len];
+        memcpy(_filePath, filePath, len * sizeof(WCHAR));
+    }
 
-	~Event()
-	{
-		delete [] _rootPath;
-		delete [] _filePath;
-	}
+    ~Event()
+    {
+        delete [] _filePath;
+    }
 };
 class Win32FSHook
 {
 private:
-	static const DWORD DELETE_WD_SIGNAL = 99999997;
-	static const DWORD EXIT_SIGNAL = 99999998;
-	static Win32FSHook *instance;
+    static const DWORD DELETE_WD_SIGNAL = 99999997;
+    static const DWORD EXIT_SIGNAL = 99999998;
+    static Win32FSHook *instance;
 
-	// running flag
-	bool _isRunning;
-	
-	// thread handle
-	HANDLE _mainLoopThreadHandle;
-	
-	HANDLE _completionPort;
+    // running flag
+    bool _isRunning;
+    
+    // thread handle
+    HANDLE _mainLoopThreadHandle;
+    
+    HANDLE _completionPort;
 
-	// critical seaction
-	CRITICAL_SECTION _cSection;
-	
-	// watch id 2 watch map
-	map<int, WatchData*> _wid2WatchData;
+    // critical seaction
+    CRITICAL_SECTION _cSection;
+    
+    // watch id 2 watch map
+    map<int, WatchData*> _wid2WatchData;
 
-	// Thread function
-	static DWORD WINAPI mainLoop( LPVOID lpParam );
+    // Thread function
+    static DWORD WINAPI mainLoop( LPVOID lpParam );
 
-	ChangeCallback _callback;
-	
-	void watchDirectory(WatchData* wd);
-	
-	CRITICAL_SECTION _eventQueueLock;
-	HANDLE _eventQueueEvent;
-	void postEvent(Event *event);
-	HANDLE _eventsThread;
-	static DWORD WINAPI eventLoop( LPVOID lpParam );
-	queue<Event*> _eventQueue;
-	WatchData* find(int wd);
+    ChangeCallback _callback;
+    
+    void watchDirectory(WatchData* wd);
+    
+    CRITICAL_SECTION _eventQueueLock;
+    HANDLE _eventQueueEvent;
+    void postEvent(Event *event);
+    HANDLE _eventsThread;
+    static DWORD WINAPI eventLoop( LPVOID lpParam );
+    queue<Event*> _eventQueue;
+    WatchData* find(int wd);
 public:
-	static const int ERR_INIT_THREAD = 1;
-	
-	Win32FSHook();
-	virtual ~Win32FSHook();
-	
-	void init(ChangeCallback callback);
-	
-	int add_watch(const WCHAR* path, long notifyFilter, bool watchSubdirs, DWORD &error);
-	void remove_watch(int watchId);
+    static const int ERR_INIT_THREAD = 1;
+    
+    Win32FSHook();
+    virtual ~Win32FSHook();
+    
+    void init(ChangeCallback callback);
+    
+    int add_watch(const WCHAR* path, int notifyFilter, bool watchSubdirs, DWORD &error);
+    void remove_watch(int watchId);
 };
 
 #endif /*WIN32FSHOOK_H_*/

--- a/win32/net_contentobjects_jnotify_win32_JNotify_win32.h
+++ b/win32/net_contentobjects_jnotify_win32_JNotify_win32.h
@@ -36,10 +36,10 @@ extern "C" {
 /*
  * Class:     net_contentobjects_jnotify_win32_JNotify_win32
  * Method:    nativeInitLogger
- * Signature: ([B)V
+ * Signature: ([BZ)V
  */
 JNIEXPORT void JNICALL Java_net_contentobjects_jnotify_win32_JNotify_1win32_nativeInitLogger
-  (JNIEnv *, jclass, jbyteArray);
+  (JNIEnv *, jclass, jbyteArray, jboolean);
 
 /*
  * Class:     net_contentobjects_jnotify_win32_JNotify_win32
@@ -52,18 +52,18 @@ JNIEXPORT jint JNICALL Java_net_contentobjects_jnotify_win32_JNotify_1win32_nati
 /*
  * Class:     net_contentobjects_jnotify_win32_JNotify_win32
  * Method:    nativeAddWatch
- * Signature: (Ljava/lang/String;JZ)I
+ * Signature: (Ljava/lang/String;IZ)I
  */
 JNIEXPORT jint JNICALL Java_net_contentobjects_jnotify_win32_JNotify_1win32_nativeAddWatch
-  (JNIEnv *, jclass, jstring, jlong, jboolean);
+  (JNIEnv *, jclass, jstring, jint, jboolean);
 
 /*
  * Class:     net_contentobjects_jnotify_win32_JNotify_win32
  * Method:    getErrorDesc
- * Signature: (J)Ljava/lang/String;
+ * Signature: (I)Ljava/lang/String;
  */
 JNIEXPORT jstring JNICALL Java_net_contentobjects_jnotify_win32_JNotify_1win32_getErrorDesc
-  (JNIEnv *, jclass, jlong);
+  (JNIEnv *, jclass, jint);
 
 /*
  * Class:     net_contentobjects_jnotify_win32_JNotify_win32


### PR DESCRIPTION
Correctly restart watch after queue overflow
Call java callback with special QUEUE_OVERFLOW action code
Cleanup win32 notification API
Runtime-controlled log level
Avoid unnecessary copies
Cleanup indent
